### PR TITLE
Fix #39. Add tests for *.js files

### DIFF
--- a/testWorkspace/index.js
+++ b/testWorkspace/index.js
@@ -1,0 +1,24 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+export default class MainComponent extends React.Component {
+    render() {
+        return (
+            <div className="daitro">
+                <StatelessComponent />
+            </div>
+        );
+    }
+}
+
+function StatelessComponent(props) {
+    return (
+        <div className="haveheart">
+            <h1>Turnstile is: {props.boolProp}</h1>
+        </div>
+    );
+}
+
+StatelessComponent.propTypes = {
+    boolProp: PropTypes.bool
+};


### PR DESCRIPTION
In the 1.0.1 version we've added *.js files support but didn't provide
any tests for this behaviour. A simple test was added for a *.js
file with stateless component.

<!---
Before submitting a pull request, please make sure the following is done:

Fork the repository and create your branch from master.
Run npm in the repository root.
If you've fixed a bug or added code that should be tested, add tests!
Ensure the test suite passes (npm test). Also you can launch tests using "Extension Tests" vscode task.
Thanks! --->
