### PR TITLE
Fix stateless components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "react-proptypes-intellisense",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   "dependencies": {
     "@types/glob": "^5.0.35",
     "babel-traverse": "^6.26.0",
+    "babel-types": "^6.26.0",
     "babylon": "^6.18.0",
     "decache": "^4.4.0",
     "glob": "^7.1.2",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,9 +1,8 @@
-'use strict';
-import { languages, ExtensionContext } from 'vscode';
+import { languages } from 'vscode';
 
 import PropTypesCompletionItemProvider from './PropTypesCompletionItemProvider';
 
-export function activate(context: ExtensionContext) {
+export function activate() {
     const propTypesCompletionItemProvider = new PropTypesCompletionItemProvider();
 
     languages.registerCompletionItemProvider(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -50,24 +50,27 @@ export const isRequiredPropType = (propType: string): boolean => {
     return propTypeSeparatedByDot[propTypeSeparatedByDot.length - 1] === 'isRequired';
 };
 
+const isPathToTypingFile = (path: string): boolean => basename(path).endsWith('.d.ts');
+
 export const getDefinition = async (
     documentUri: Uri,
     position: Position
 ): Promise<Location | undefined> => {
-    const definitions = <{}[]>await commands.executeCommand(
-        'vscode.executeTypeDefinitionProvider',
+    const definitions = <Location[]>await commands.executeCommand(
+        'vscode.executeDefinitionProvider',
         documentUri,
         position
     );
 
-    if (!definitions.length) {
+    const definitionsWithoutTypings = definitions.filter(
+        (definition: Location) => !isPathToTypingFile(definition.uri.path)
+    );
+
+    const length = definitionsWithoutTypings.length;
+
+    if (!length) {
         return undefined;
     }
 
-    return <Location>definitions[0];
+    return definitionsWithoutTypings[length - 1];
 };
-
-export const isReactComponent = (nameOfJsxTag: string): boolean =>
-    nameOfJsxTag[0] === nameOfJsxTag[0].toUpperCase();
-
-export const isPathToTypingFile = (path: string): boolean => basename(path).includes('.d.ts');

--- a/test/extension.test.ts
+++ b/test/extension.test.ts
@@ -296,6 +296,16 @@ suite('Extension suggestions integration tests', () => {
         );
     });
 
+    test('Find props for a stateless component written with an arrow function', () => {
+        const cursorPositionForComponent = new vscode.Position(7, 36);
+
+        return checkCompletionItemsForSpecificPosition(
+            cursorPositionForComponent,
+            [boolCompletionItem],
+            'StatelessComponentArrowFunctionTest.jsx'
+        );
+    });
+
     test.skip('Find props for an anonymous component', () => {
         const cursorPositionForComponent = new vscode.Position(7, 36);
 
@@ -303,16 +313,6 @@ suite('Extension suggestions integration tests', () => {
             cursorPositionForComponent,
             proposal,
             'ImportedAnonymousComponentTest.jsx'
-        );
-    });
-
-    test.skip('Find props for a stateless component written with an arrow function', () => {
-        const cursorPositionForComponent = new vscode.Position(7, 36);
-
-        return checkCompletionItemsForSpecificPosition(
-            cursorPositionForComponent,
-            [boolCompletionItem],
-            'StatelessComponentArrowFunctionTest.jsx'
         );
     });
 });


### PR DESCRIPTION
Fix #46 

- fix working with arrow function components
- unskip test for arrow function components
- add babel-type into package.json file

